### PR TITLE
📝 README.md: Add Kimi support & config instructions (English)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -72,16 +72,77 @@ Claude Codeは適切なコンテキストがあってこそ最高の結果を発
 任意のフォルダで右クリック、"Claude Code Now" を選択して起動。
 
 ### 🔧 API設定スイッチャー
+
 **ワンクリックAPI設定切り替え**、ローカル安全保存。
 
 **対応API：**
 - **Zhipu AI** (GLM) - 中国国内ユーザー向け
+- **Kimi** (月の暗面) - 高速 thinking-turbo モデル
 - **Anthropic 公式** - 海外ユーザー向け
 - **カスタム API** - その他互換サービス
 
+**ミニマルバージョン（85行のみ）：**
+
+GUIアプリ不要のコマンドライン版を使用：
+
+```bash
+cd config-switcher
+./config-simpler.sh
+```
+
+**対応設定：**
+1. zhipu - Zhipu AI
+2. kimi - Kimi（高速 thinking-turbo）
+3. anthropic - Anthropic 公式
+4. custom - カスタム設定
+
+**設定ファイルの作成方法：**
+
+ミニマルバージョンはプリセット設定ファイルを使用します。作成方法：
+
+```bash
+cd ~
+
+# 1. Zhipu AI設定の作成
+cp .claude/settings.json .claude/settings_zhipu.json
+
+# 2. Zhipu APIキーで設定を編集
+# .claude/settings_zhipu.json を編集し、ANTHROPIC_AUTH_TOKEN と ANTHROPIC_BASE_URL を修正
+
+# 3. 同様の方法で他の設定を作成
+cp .claude/settings.json .claude/settings_kimi.json
+cp .claude/settings.json .claude/settings_anthropic.json
+cp .claude/settings.json .claude/settings_custom.json
+```
+
+**設定ファイルテンプレート：**
+
+**Zhipu AI (zhipu):**
+```json
+{
+  "env": {
+    "ANTHROPIC_AUTH_TOKEN": "your_zhipu_api_key",
+    "ANTHROPIC_BASE_URL": "https://open.bigmodel.cn/api/anthropic",
+    "API_TIMEOUT_MS": "3000000"
+  }
+}
+```
+
+**Kimi (kimi):**
+```json
+{
+  "env": {
+    "ANTHROPIC_AUTH_TOKEN": "your_kimi_api_key",
+    "ANTHROPIC_BASE_URL": "https://api.moonshot.cn/anthropic",
+    "ANTHROPIC_MODEL": "kimi-k2-thinking-turbo",
+    "API_TIMEOUT_MS": "3000000"
+  }
+}
+```
+
 **セキュリティ：** API キーはローカル保存、アップロードされません。
 
-**使用方法：** `config-switcher/Claude Config Switcher.app` に移動
+**GUIを使用：** `config-switcher/Claude Config Switcher.app` に移動
 
 ### 📁 ユニバーサル起動
 アプリをどこにでも配置、アイコンをクリックで直接起動。

--- a/README.md
+++ b/README.md
@@ -75,16 +75,77 @@ Drag the app to Finder toolbar, click to launch in any folder.
 Right-click on any folder to launch Claude Code Now.
 
 ### 🔧 API Config Switcher
+
 **One-click API configuration switching** with secure local storage.
 
 **Supported APIs:**
 - **Zhipu AI** (GLM) - Best for China users
+- **Kimi** (Moonshot AI) - High-speed thinking-turbo model
 - **Anthropic Official** - International users  
 - **Custom API** - Other compatible services
 
+**Minimal Version (Only 85 lines):**
+
+Use the command-line version without GUI app:
+
+```bash
+cd config-switcher
+./config-simpler.sh
+```
+
+**Supported Configs:**
+1. zhipu - Zhipu AI
+2. kimi - Moonshot AI (High-speed thinking-turbo)
+3. anthropic - Anthropic Official
+4. custom - Custom configuration
+
+**How to Add Configuration Files:**
+
+The minimal version uses preset configuration files. Here's how to create them:
+
+```bash
+cd ~
+
+# 1. Create Zhipu AI config
+cp .claude/settings.json .claude/settings_zhipu.json
+
+# 2. Edit the config with your Zhipu API key
+# Edit .claude/settings_zhipu.json, modify ANTHROPIC_AUTH_TOKEN and ANTHROPIC_BASE_URL
+
+# 3. Create other configs the same way
+cp .claude/settings.json .claude/settings_kimi.json
+cp .claude/settings.json .claude/settings_anthropic.json
+cp .claude/settings.json .claude/settings_custom.json
+```
+
+**Configuration File Templates:**
+
+**Zhipu AI (zhipu):**
+```json
+{
+  "env": {
+    "ANTHROPIC_AUTH_TOKEN": "your_zhipu_api_key",
+    "ANTHROPIC_BASE_URL": "https://open.bigmodel.cn/api/anthropic",
+    "API_TIMEOUT_MS": "3000000"
+  }
+}
+```
+
+**Kimi (kimi)::**
+```json
+{
+  "env": {
+    "ANTHROPIC_AUTH_TOKEN": "your_kimi_api_key",
+    "ANTHROPIC_BASE_URL": "https://api.moonshot.cn/anthropic",
+    "ANTHROPIC_MODEL": "kimi-k2-thinking-turbo",
+    "API_TIMEOUT_MS": "3000000"
+  }
+}
+```
+
 **Security:** API keys stored locally, never uploaded anywhere.
 
-**Usage:** Navigate to `config-switcher/Claude Config Switcher.app`
+**Use GUI:** Navigate to `config-switcher/Claude Config Switcher.app`
 
 ### 📁 Universal Launch
 Put the APP in any folder, click the icon to launch directly.


### PR DESCRIPTION
Synchronized English README.md with Chinese version:

- Added Kimi (Moonshot AI) support to API configuration switcher
- Added minimal CLI version documentation (config-simpler.sh)
- Included step-by-step guide for creating preset configuration files
- Provided JSON configuration templates
- Documented security practices and CLI vs GUI usage

Completes the README update started in previous PR.