### PR TITLE
📦 Add preset config templates & update all READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -140,6 +140,26 @@ cp .claude/settings.json .claude/settings_custom.json
 }
 ```
 
+**プリセットテンプレートで簡単設定：**
+
+`config-switcher/presets/` に4つのプリ設定テンプレートを用意：
+
+```bash
+# すべてのプリ設定を ~/.claude/ にコピー
+cd ~/.claude
+cp /path/to/claude-code-now/config-switcher/presets/settings*.json .
+```
+
+または個別にコピー：
+```bash
+cp /path/to/claude-code-now/config-switcher/presets/settings_anthropic.json ~/.claude/
+cp /path/to/claude-code-now/config-switcher/presets/settings_kimi.json ~/.claude/
+cp /path/to/claude-code-now/config-switcher/presets/settings_zhipu.json ~/.claude/
+cp /path/to/claude-code-now/config-switcher/presets/settings_custom.json ~/.claude/
+```
+
+その後、実際のAPIキーでファイルを編集すれば設定スイッチャーが使用可能！
+
 **セキュリティ：** API キーはローカル保存、アップロードされません。
 
 **GUIを使用：** `config-switcher/Claude Config Switcher.app` に移動

--- a/README.md
+++ b/README.md
@@ -143,6 +143,26 @@ cp .claude/settings.json .claude/settings_custom.json
 }
 ```
 
+**Quick Setup with Preset Templates:**
+
+We provide 4 preset configuration templates in `config-switcher/presets/`:
+
+```bash
+# Copy all preset configs to ~/.claude/
+cd ~/.claude
+cp /path/to/claude-code-now/config-switcher/presets/settings*.json .
+```
+
+Or copy individually:
+```bash
+cp /path/to/claude-code-now/config-switcher/presets/settings_anthropic.json ~/.claude/
+cp /path/to/claude-code-now/config-switcher/presets/settings_kimi.json ~/.claude/
+cp /path/to/claude-code-now/config-switcher/presets/settings_zhipu.json ~/.claude/
+cp /path/to/claude-code-now/config-switcher/presets/settings_custom.json ~/.claude/
+```
+
+Then edit the files with your actual API keys and you're ready to use the config switcher!
+
 **Security:** API keys stored locally, never uploaded anywhere.
 
 **Use GUI:** Navigate to `config-switcher/Claude Config Switcher.app`

--- a/README.zh.md
+++ b/README.zh.md
@@ -140,6 +140,26 @@ cp .claude/settings.json .claude/settings_custom.json
 }
 ```
 
+**快速使用预设模板：**
+
+我们在 `config-switcher/presets/` 提供了4个预设配置文件：
+
+```bash
+# 复制所有预设配置到 ~/.claude/
+cd ~/.claude
+cp /path/to/claude-code-now/config-switcher/presets/settings*.json .
+```
+
+或者单独复制：
+```bash
+cp /path/to/claude-code-now/config-switcher/presets/settings_anthropic.json ~/.claude/
+cp /path/to/claude-code-now/config-switcher/presets/settings_kimi.json ~/.claude/
+cp /path/to/claude-code-now/config-switcher/presets/settings_zhipu.json ~/.claude/
+cp /path/to/claude-code-now/config-switcher/presets/settings_custom.json ~/.claude/
+```
+
+然后编辑文件填入你的实际API密钥即可使用配置切换器！
+
 **安全性：** API密钥本地存储，绝不上传。
 
 **使用图形界面：** 进入 `config-switcher/Claude Config Switcher.app`

--- a/config-switcher/presets/settings_anthropic.json
+++ b/config-switcher/presets/settings_anthropic.json
@@ -1,0 +1,8 @@
+{
+    "env": {
+        "ANTHROPIC_AUTH_TOKEN": "your_anthropic_api_key_here",
+        "ANTHROPIC_BASE_URL": "https://api.anthropic.com",
+        "API_TIMEOUT_MS": "300000",
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": 1
+    }
+}

--- a/config-switcher/presets/settings_custom.json
+++ b/config-switcher/presets/settings_custom.json
@@ -1,0 +1,8 @@
+{
+    "env": {
+        "ANTHROPIC_AUTH_TOKEN": "your_custom_api_key_here",
+        "ANTHROPIC_BASE_URL": "your_custom_base_url_here",
+        "API_TIMEOUT_MS": "3000000",
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": 1
+    }
+}

--- a/config-switcher/presets/settings_kimi.json
+++ b/config-switcher/presets/settings_kimi.json
@@ -1,0 +1,13 @@
+{
+    "env": {
+        "ANTHROPIC_AUTH_TOKEN": "your_kimi_api_key_here",
+        "ANTHROPIC_BASE_URL": "https://api.moonshot.cn/anthropic",
+        "ANTHROPIC_MODEL": "kimi-k2-thinking-turbo",
+        "ANTHROPIC_DEFAULT_OPUS_MODEL": "kimi-k2-thinking-turbo",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL": "kimi-k2-thinking-turbo",
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL": "kimi-k2-thinking-turbo",
+        "CLAUDE_CODE_SUBAGENT_MODEL": "kimi-k2-thinking-turbo",
+        "API_TIMEOUT_MS": "3000000",
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": 1
+    }
+}

--- a/config-switcher/presets/settings_zhipu.json
+++ b/config-switcher/presets/settings_zhipu.json
@@ -1,0 +1,8 @@
+{
+    "env": {
+        "ANTHROPIC_AUTH_TOKEN": "your_zhipu_api_key_here",
+        "ANTHROPIC_BASE_URL": "https://open.bigmodel.cn/api/anthropic",
+        "API_TIMEOUT_MS": "3000000",
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": 1
+    }
+}


### PR DESCRIPTION
Added preset configuration templates and updated all README files:\n\n## Changes\n\n- Created  directory with 4 safe template files:\n  - settings_anthropic.json (Anthropic official)\n  - settings_kimi.json (Kimi/Moonshot AI)\n  - settings_zhipu.json (Zhipu AI)\n  - settings_custom.json (Custom API)\n\n- All templates use placeholder API keys (your_*_api_key_here) - no real keys leaked\n\n- Updated all README files (EN/ZH/JA) with copy-paste instructions:\n  - Added "Quick Setup with Preset Templates" section to each language\n  - Users can now copy directly: \n  - Or copy individual files as needed\n\n## Security\n\n- ✅ All templates use placeholder keys only\n- ✅ No real API credentials in repository\n- ✅ Users edit locally with their own keys\n\n## Usage\n\n\n\n🤖 Generated with [Claude Code](https://claude.ai/code)\n\nCo-Authored-By: Claude <noreply@anthropic.com>